### PR TITLE
Backward compatibility for KREDITKARTENABRECHNUNG

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -105,7 +105,7 @@ namespace FireflyFixTransactionReportDKB
                 if (string.IsNullOrWhiteSpace(importFileContent[i]) || importFileContent[i].StartsWith("\"Kontonummer:\";\"DE") || importFileContent[i].StartsWith("\"Von:\";\"")
                     || importFileContent[i].StartsWith("\"Bis:\";\"") || importFileContent[i].StartsWith("\"Kontostand vom ") || importFileContent[i].StartsWith("\"Kreditkarte:\";\"")
                     || importFileContent[i].StartsWith("\"Zeitraum:\";\"") || importFileContent[i].StartsWith("\"Saldo:\";\"") || importFileContent[i].StartsWith("\"Datum:\";\"")
-                    || importFileContent[i].Contains("\"KREDITKARTENABRECHNUNG VISA") || importFileContent[i].Contains(";\"Abschluss\";"))
+                    || importFileContent[i].Contains("\"KREDITKARTENABRECHNUNG") || importFileContent[i].Contains(";\"Abschluss\";"))
                 {
                     // Remove the unwanted line from the list.
                     importFileContent.RemoveAt(i);


### PR DESCRIPTION
It looks like DKB changed their transaction format for the "Kreditkartenabrechnung" at some point in 2021. I noticed this when processing some older CSV exports, where the entry wasn't filtered out properly. This PR slightly tweaks the filter so that it works with both the old and the new format